### PR TITLE
Fixed bug that would prevent creation of non-existing databases

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -62,7 +62,7 @@ WpDatabase.prototype.connect = function(cb) {
 	connection = mysql.createConnection({
 		host: this.host,
 		user: this.user,
-		password: this.pass,
+		password: this.password,
 		name: this.name,
 	});
 


### PR DESCRIPTION
The mysql connection was set to use this.pass rather than this.password. This prevented databases from being created as the connection would fail
