### PR TITLE
Updated getCurrentVersion regex

### DIFF
--- a/lib/misc.js
+++ b/lib/misc.js
@@ -45,27 +45,27 @@ wpMisc.getCurrentVersion = function(cb) {
 	// Default version
 	var latestVersion = '3.8';
 
-	// Get the most recent WP version from the Wordpress version API
-	https.get(wpMisc.urls.version, function(res) {
-		if (res.statusCode != 200) {
-			return cb(new Error(res), latestVersion);
+	// List the tags
+	git.listRemote('--tags ' + wpMisc.urls.gitRepo, function(err, tagsList) {
+
+    // Fail on error, return default
+		if (err) return cb(err, latestVersion);
+
+		// Split the tags on new lines
+		tagList = ('' + tagsList).split('\n');
+
+		// The last line is empty
+		tagList.pop();
+
+		// The next to last line is the most recent tag
+		lastTag = /[^/]+$/ig.exec(tagList.pop());
+
+		// If there was a match, set it
+		if (lastTag !== null) {
+			latestVersion = lastTag[0];
 		}
 
-		var body = '';
-		var response;
-
-		res.on('data', function(c){
-			body += c;
-		}).on('end', function(){
-			response = JSON.parse(body);
-
-			latestVersion = response.offers[0].current ? response.offers[0].current : latestVersion;
-			return cb(null, latestVersion);
-		});
-
-	}).on('error', function(err){
-		console.error('Error getting Wordpress version: ' + err);
-		return cb(new Error(res), latestVersion);
+		// Done
+		cb(null, latestVersion);
 	});
-
 };

--- a/lib/misc.js
+++ b/lib/misc.js
@@ -58,7 +58,7 @@ wpMisc.getCurrentVersion = function(cb) {
 		tagList.pop();
 
 		// The next to last line is the most recent tag
-		lastTag = /[^/]+$/ig.exec(tagList.pop());
+		lastTag = /\d+\.\d+(\.\d+)?/ig.exec(tagList.pop());
 
 		// If there was a match, set it
 		if (lastTag !== null) {

--- a/lib/misc.js
+++ b/lib/misc.js
@@ -48,7 +48,7 @@ wpMisc.getCurrentVersion = function(cb) {
 	// List the tags
 	git.listRemote('--tags ' + wpMisc.urls.gitRepo, function(err, tagsList) {
 
-    // Fail on error, return default
+		// Fail on error, return default
 		if (err) return cb(err, latestVersion);
 
 		// Split the tags on new lines

--- a/lib/misc.js
+++ b/lib/misc.js
@@ -45,26 +45,27 @@ wpMisc.getCurrentVersion = function(cb) {
 	// Default version
 	var latestVersion = '3.8';
 
-	// List the tags
-	git.listRemote('--tags ' + wpMisc.urls.gitRepo, function(err, tagsList) {
-		// Fail on error, return default
-		if (err) return cb(err, latestVersion);
-
-		// Split the tags on new lines
-		tagList = ('' + tagsList).split('\n');
-
-		// The last line is empty
-		tagList.pop();
-
-		// The next to last line is the most recent tag
-		lastTag = /\d\.\d\.\d/ig.exec(tagList.pop());
-
-		// If there was a match, set it
-		if (lastTag !== null) {
-			latestVersion = lastTag[0];
+	// Get the most recent WP version from the Wordpress version API
+	https.get(wpMisc.urls.version, function(res) {
+		if (res.statusCode != 200) {
+			return cb(new Error(res), latestVersion);
 		}
 
-		// Done
-		cb(null, latestVersion);
+		var body = '';
+		var response;
+
+		res.on('data', function(c){
+			body += c;
+		}).on('end', function(){
+			response = JSON.parse(body);
+
+			latestVersion = response.offers[0].current ? response.offers[0].current : latestVersion;
+			return cb(null, latestVersion);
+		});
+
+	}).on('error', function(err){
+		console.error('Error getting Wordpress version: ' + err);
+		return cb(new Error(res), latestVersion);
 	});
+
 };

--- a/lib/misc.js
+++ b/lib/misc.js
@@ -47,7 +47,6 @@ wpMisc.getCurrentVersion = function(cb) {
 
 	// List the tags
 	git.listRemote('--tags ' + wpMisc.urls.gitRepo, function(err, tagsList) {
-
 		// Fail on error, return default
 		if (err) return cb(err, latestVersion);
 


### PR DESCRIPTION
The existing regex wasn't matching two-digit tags (e.g. 4.7). New regex grabs everything after the last slash.